### PR TITLE
Modify CODEOWNERS for directory ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # CODEOWNERS file to define individuals or teams that are responsible for code in a repository.
 # To restrict users from modifying the pipeline definitions, update this file with specific owners.
 
-/.azure_pipelines/      @adeelmalik78 @daticalamy @don-liquibase @dreads @recampbell
-/.github/               @adeelmalik78 @daticalamy @don-liquibase @dreads @recampbell
+/.azure_pipelines/      @adeelmalik78 @daticalamy @molivasdat @recampbell
+/.github/               @adeelmalik78 @daticalamy @molivasdat @recampbell


### PR DESCRIPTION
Updated CODEOWNERS to replace 'don-liquibase' with 'molivasdat' for specified directories.